### PR TITLE
Expose public url for files on demand

### DIFF
--- a/templates/bucket_contents.html
+++ b/templates/bucket_contents.html
@@ -19,7 +19,7 @@
     {% if item.type == "folder" %}
       <a href="{{ url_for('view_bucket', bucket_name=bucket_name, path=item.name) }}">{{ item.name }}</a>
     {% else %}
-      {{ item.date_modified }} | {{ item.size }} | <a href="{{ item.url }}" target="_blank">{{ item.name }}</a>
+      {{ item.date_modified }} | {{ item.size }} | <a href="{{ url_for('download_file', bucket_name=bucket_name, path=item.name) }}" target="_blank">{{ item.name }}</a>
     {% endif %}
   </li>
   {% endfor %}


### PR DESCRIPTION
For better security, expose the download url only when it is requested
This will also allow for faster load times of heavy buckets
